### PR TITLE
Revert faker version update to avoid seeding errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "uglifier", ">= 1.3.0"
 gem "wicked_pdf"
 gem "wkhtmltopdf-binary"
 
-gem "faker", "~> 2.14.0"
+gem "faker", "~> 1.9"
 
 gem "puma"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,8 +397,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    faker (2.14.0)
-      i18n (>= 1.6, < 2)
+    faker (1.9.6)
+      i18n (>= 0.7)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
@@ -835,7 +835,7 @@ DEPENDENCIES
   decidim-dev!
   decidim-elections!
   decidim-initiatives!
-  faker (~> 2.14.0)
+  faker (~> 1.9)
   fog-aws
   letter_opener_web (~> 1.4.0)
   listen (~> 3.1.0)


### PR DESCRIPTION
This version should match the gem version used by Decidim.