### PR TITLE
Remove sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,4 @@ group :production do
   gem "scout_apm"
   gem "sendgrid-ruby"
   gem "sentry-raven"
-  gem "sidekiq"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,6 @@ GEM
     coffee-script-source (1.12.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
-    connection_pool (2.2.3)
     crack (0.4.4)
     crass (1.0.6)
     css_parser (1.7.1)
@@ -743,10 +742,6 @@ GEM
     sentry-raven (3.1.0)
       faraday (>= 1.0)
     seven_zip_ruby (1.3.0)
-    sidekiq (6.1.2)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -852,7 +847,6 @@ DEPENDENCIES
   scout_apm
   sendgrid-ruby
   sentry-raven
-  sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets (~> 3.7.2)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml
 release: bundle exec rake db:migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  config.active_job.queue_adapter     = :sidekiq
+  config.active_job.queue_adapter     = :async
   # config.active_job.queue_name_prefix = "decidim_staging_#{Rails.env}"
   config.action_mailer.perform_caching = false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,7 @@
-require "sidekiq/web"
-
 Rails.application.routes.draw do
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
   mount Decidim::Core::Engine => "/"
-  authenticate :user, lambda { |u| u.admin? } do
-    mount Sidekiq::Web => "/sidekiq"
-  end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,9 +1,0 @@
-:concurrency: 5
-:queues:
-- ["default", 1]
-- ["mailers", 1]
-- ["newsletter", 1]
-- ["newsletter_opt_in", 1]
-- ["events", 1]
-- ["metrics", 1]
-- ["conference_diplomas", 1]


### PR DESCRIPTION
## ✍️ Description

This PR removes Sidekiq for the production environment and changes the handling of jobs to "standard" `async`. Like this, we don't have to enable the worker for review apps.

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [ ] Manually check that it's working.
- [ ] Add documentation and tests if needed.
