### PR TITLE
Remove unnecessary gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,11 @@ ruby RUBY_VERSION
 DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", branch: "develop" }
 
 gem "decidim", DECIDIM_VERSION
-gem "decidim-conferences", DECIDIM_VERSION
-gem "decidim-consultations", DECIDIM_VERSION
-gem "decidim-dev", DECIDIM_VERSION
-gem "decidim-elections", DECIDIM_VERSION
-gem "decidim-initiatives", DECIDIM_VERSION
-gem "decidim-templates", DECIDIM_VERSION
+#gem "decidim-conferences", DECIDIM_VERSION
+#gem "decidim-consultations", DECIDIM_VERSION
+#gem "decidim-elections", DECIDIM_VERSION
+#gem "decidim-initiatives", DECIDIM_VERSION
+#gem "decidim-templates", DECIDIM_VERSION
 
 gem "ransack", "~> 2.1.1"
 
@@ -30,6 +29,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "decidim-dev", DECIDIM_VERSION
   gem "letter_opener_web", "~> 1.4.0"
   gem "listen", "~> 3.1.0"
   gem "spring"
@@ -38,11 +38,8 @@ group :development do
 end
 
 group :production do
-  gem "dalli"
   gem "fog-aws"
   gem "lograge"
-  gem "newrelic_rpm"
-  gem "scout_apm"
   gem "sendgrid-ruby"
   gem "sentry-raven"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: f23ef15e189cbcea5f3f382c3a3268d81e958d27
+  revision: 6d91e79f0b5f0287e47290154488ebbba459b436
   branch: develop
   specs:
     decidim (0.24.0.dev)
@@ -61,15 +61,6 @@ GIT
       decidim-core (= 0.24.0.dev)
       jquery-rails (~> 4.4)
       redcarpet (~> 3.4)
-    decidim-conferences (0.24.0.dev)
-      decidim-core (= 0.24.0.dev)
-      decidim-meetings (= 0.24.0.dev)
-      wicked_pdf (~> 1.4)
-      wkhtmltopdf-binary (~> 0.12)
-    decidim-consultations (0.24.0.dev)
-      decidim-admin (= 0.24.0.dev)
-      decidim-comments (= 0.24.0.dev)
-      decidim-core (= 0.24.0.dev)
     decidim-core (0.24.0.dev)
       active_link_to (~> 1.0)
       anchored (>= 1.1.0)
@@ -160,28 +151,12 @@ GIT
       vcr (~> 6.0)
       webmock (~> 3.6)
       wisper-rspec (~> 1.0)
-    decidim-elections (0.24.0.dev)
-      decidim-bulletin_board (= 0.2.0)
-      decidim-core (= 0.24.0.dev)
-      decidim-forms (= 0.24.0.dev)
-      decidim-proposals (= 0.24.0.dev)
     decidim-forms (0.24.0.dev)
       decidim-core (= 0.24.0.dev)
       wicked_pdf (~> 1.4)
       wkhtmltopdf-binary (~> 0.12)
     decidim-generators (0.24.0.dev)
       decidim-core (= 0.24.0.dev)
-    decidim-initiatives (0.24.0.dev)
-      decidim-admin (= 0.24.0.dev)
-      decidim-comments (= 0.24.0.dev)
-      decidim-core (= 0.24.0.dev)
-      decidim-verifications (= 0.24.0.dev)
-      kaminari (~> 1.2, >= 1.2.1)
-      origami (~> 2.1)
-      virtus-multiparams (~> 0.1)
-      wicked (~> 1.3)
-      wicked_pdf (~> 1.4)
-      wkhtmltopdf-binary (~> 0.12)
     decidim-meetings (0.24.0.dev)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)
@@ -342,27 +317,18 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    colorize (0.8.1)
     concurrent-ruby (1.1.7)
     crack (0.4.5)
       rexml
     crass (1.0.6)
     css_parser (1.7.1)
       addressable
-    dalli (2.7.10)
     date_validator (0.9.0)
       activemodel
       activesupport
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
-    decidim-bulletin_board (0.2.0)
-      activemodel (~> 5.0, >= 5.0.0.1)
-      activesupport (~> 5.0, >= 5.0.0.1)
-      byebug (~> 11.0)
-      graphlient (~> 0.4.0)
-      jwt
-      wisper (~> 2.0.0)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -418,8 +384,6 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
-    faraday_middleware (1.0.0)
-      faraday (~> 1.0)
     ffi (1.14.2)
     file_validators (2.3.0)
       activemodel (>= 3.2)
@@ -457,14 +421,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphlient (0.4.0)
-      faraday (>= 1.0)
-      faraday_middleware
-      graphql-client
     graphql (1.11.6)
-    graphql-client (0.16.0)
-      activesupport (>= 3.0)
-      graphql (~> 1.8)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -564,7 +521,6 @@ GEM
     multipart-post (2.1.1)
     mustache (1.1.1)
     netrc (0.11.0)
-    newrelic_rpm (6.13.0)
     nio4r (2.5.4)
     nobspw (0.6.2)
     nokogiri (1.11.1)
@@ -599,8 +555,6 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    origami (2.1.0)
-      colorize (~> 0.7)
     orm_adapter (0.5.0)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
@@ -759,8 +713,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scout_apm (2.6.10)
-      parser
     searchlight (4.1.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -826,8 +778,6 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    virtus-multiparams (0.1.1)
-      virtus (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (3.7.0)
@@ -842,8 +792,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked (1.3.4)
-      railties (>= 3.0.7)
     wicked_pdf (1.4.0)
       activesupport
     wisper (2.0.1)
@@ -857,23 +805,15 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  dalli
   decidim!
-  decidim-conferences!
-  decidim-consultations!
   decidim-dev!
-  decidim-elections!
-  decidim-initiatives!
-  decidim-templates!
   faker (~> 2.14)
   fog-aws
   letter_opener_web (~> 1.4.0)
   listen (~> 3.1.0)
   lograge
-  newrelic_rpm
   puma
   ransack (~> 2.1.1)
-  scout_apm
   sendgrid-ruby
   sentry-raven
   spring
@@ -885,7 +825,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/db/migrate/20201009122687_add_commentable_counter_cache_to_consultations.decidim_consultations.rb
+++ b/db/migrate/20201009122687_add_commentable_counter_cache_to_consultations.decidim_consultations.rb
@@ -3,8 +3,11 @@
 
 class AddCommentableCounterCacheToConsultations < ActiveRecord::Migration[5.2]
   def change
-    add_column :decidim_consultations_questions, :comments_count, :integer, null: false, default: 0, index: true
-    Decidim::Consultations::Question.reset_column_information
-    Decidim::Consultations::Question.find_each(&:update_comments_count)
+    if defined?(Decidim::Consultations)
+      add_column :decidim_consultations_questions, :comments_count, :integer, null: false, default: 0, index: true
+
+      Decidim::Consultations::Question.reset_column_information
+      Decidim::Consultations::Question.find_each(&:update_comments_count)
+    end
   end
 end

--- a/db/migrate/20201009122737_move_signature_type_to_initative_type.decidim_initiatives.rb
+++ b/db/migrate/20201009122737_move_signature_type_to_initative_type.decidim_initiatives.rb
@@ -7,33 +7,35 @@ class MoveSignatureTypeToInitativeType < ActiveRecord::Migration[5.2]
   end
 
   def change
-    if !ActiveRecord::Base.connection.table_exists?("decidim_initiatives_types")
-      Rails.logger.info "Skipping migration since there's no InitiativesType table"
-      return
-    elsif InitiativesType.count.positive?
-      raise "You need to edit this migration to continue"
+    if defined?(Decidim::Initiatives)
+      if !ActiveRecord::Base.connection.table_exists?("decidim_initiatives_types")
+        Rails.logger.info "Skipping migration since there's no InitiativesType table"
+        return
+      elsif InitiativesType.count.positive?
+        raise "You need to edit this migration to continue"
+      end
+
+      # This flag says when mixed and face-to-face voting methods
+      # are allowed. If set to false, only online voting will be
+      # allowed
+      # face_to_face_voting_allowed = true
+
+      add_column :decidim_initiatives_types, :signature_type, :integer, null: false, default: 0
+
+      InitiativesType.reset_column_information
+
+      Decidim::Initiatives::InitiativesType.find_each do |type|
+        type.signature_type = if type.online_signature_enabled && face_to_face_voting_allowed
+                                :any
+                              elsif type.online_signature_enabled && !face_to_face_voting_allowed
+                                :online
+                              else
+                                :offline
+                              end
+        type.save!
+      end
+
+      remove_column :decidim_initiatives_types, :online_signature_enabled
     end
-
-    # This flag says when mixed and face-to-face voting methods
-    # are allowed. If set to false, only online voting will be
-    # allowed
-    # face_to_face_voting_allowed = true
-
-    add_column :decidim_initiatives_types, :signature_type, :integer, null: false, default: 0
-
-    InitiativesType.reset_column_information
-
-    Decidim::Initiatives::InitiativesType.find_each do |type|
-      type.signature_type = if type.online_signature_enabled && face_to_face_voting_allowed
-                              :any
-                            elsif type.online_signature_enabled && !face_to_face_voting_allowed
-                              :online
-                            else
-                              :offline
-                            end
-      type.save!
-    end
-
-    remove_column :decidim_initiatives_types, :online_signature_enabled
   end
 end

--- a/db/migrate/20201009122749_add_commentable_counter_cache_to_initiatives.decidim_initiatives.rb
+++ b/db/migrate/20201009122749_add_commentable_counter_cache_to_initiatives.decidim_initiatives.rb
@@ -3,8 +3,10 @@
 
 class AddCommentableCounterCacheToInitiatives < ActiveRecord::Migration[5.2]
   def change
-    add_column :decidim_initiatives, :comments_count, :integer, null: false, default: 0, index: true
-    Decidim::Initiative.reset_column_information
-    Decidim::Initiative.find_each(&:update_comments_count)
+    if defined?(Decidim::Consultations)
+      add_column :decidim_initiatives, :comments_count, :integer, null: false, default: 0, index: true
+      Decidim::Initiative.reset_column_information
+      Decidim::Initiative.find_each(&:update_comments_count)
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -600,7 +600,6 @@ ActiveRecord::Schema.define(version: 2021_01_14_112422) do
     t.integer "min_votes"
     t.integer "response_groups_count", default: 0, null: false
     t.jsonb "instructions"
-    t.integer "comments_count", default: 0, null: false
     t.index ["decidim_consultation_id"], name: "index_consultations_questions_on_consultation_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_question_slug_and_organization", unique: true
     t.index ["decidim_scope_id"], name: "index_decidim_consultations_questions_on_decidim_scope_id"
@@ -935,7 +934,6 @@ ActiveRecord::Schema.define(version: 2021_01_14_112422) do
     t.jsonb "online_votes", default: {}
     t.jsonb "offline_votes", default: {}
     t.bigint "decidim_area_id"
-    t.integer "comments_count", default: 0, null: false
     t.index "md5((description)::text)", name: "decidim_initiatives_description_search"
     t.index ["answered_at"], name: "index_decidim_initiatives_on_answered_at"
     t.index ["decidim_area_id"], name: "index_decidim_initiatives_on_decidim_area_id"
@@ -976,13 +974,13 @@ ActiveRecord::Schema.define(version: 2021_01_14_112422) do
     t.datetime "updated_at", null: false
     t.string "banner_image"
     t.boolean "collect_user_extra_fields", default: false
+    t.boolean "online_signature_enabled", default: true, null: false
     t.jsonb "extra_fields_legal_information"
     t.integer "minimum_committee_members"
     t.boolean "validate_sms_code_on_votes", default: false
     t.string "document_number_authorization_handler"
     t.boolean "undo_online_signatures_enabled", default: true, null: false
     t.boolean "promoting_committee_enabled", default: true, null: false
-    t.integer "signature_type", default: 0, null: false
     t.boolean "child_scope_threshold_enabled", default: false, null: false
     t.boolean "only_global_scope_enabled", default: false, null: false
     t.boolean "custom_signature_end_date_enabled", default: false, null: false


### PR DESCRIPTION
## ✍️ Description

After updating to Ruby 2.7 and latest Decidim it seems that Review Apps are crashing because they're taking too much time to boot. Let's see if removing unused gems reduces the boot time.