### PR TITLE
chore: restore decidim-eletcions gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", branch: "develop"
 gem "decidim", DECIDIM_VERSION
 #gem "decidim-conferences", DECIDIM_VERSION
 #gem "decidim-consultations", DECIDIM_VERSION
-#gem "decidim-elections", DECIDIM_VERSION
+gem "decidim-elections", DECIDIM_VERSION
 #gem "decidim-initiatives", DECIDIM_VERSION
 #gem "decidim-templates", DECIDIM_VERSION
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: 6d91e79f0b5f0287e47290154488ebbba459b436
+  revision: 65109b7cdc9b9f63893ece4989e7a9d2c8e245a1
   branch: develop
   specs:
     decidim (0.24.0.dev)
@@ -151,6 +151,11 @@ GIT
       vcr (~> 6.0)
       webmock (~> 3.6)
       wisper-rspec (~> 1.0)
+    decidim-elections (0.24.0.dev)
+      decidim-bulletin_board (= 0.2.0)
+      decidim-core (= 0.24.0.dev)
+      decidim-forms (= 0.24.0.dev)
+      decidim-proposals (= 0.24.0.dev)
     decidim-forms (0.24.0.dev)
       decidim-core (= 0.24.0.dev)
       wicked_pdf (~> 1.4)
@@ -329,6 +334,13 @@ GEM
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
+    decidim-bulletin_board (0.2.0)
+      activemodel (~> 5.0, >= 5.0.0.1)
+      activesupport (~> 5.0, >= 5.0.0.1)
+      byebug (~> 11.0)
+      graphlient (~> 0.4.0)
+      jwt
+      wisper (~> 2.0.0)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -384,6 +396,8 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.14.2)
     file_validators (2.3.0)
       activemodel (>= 3.2)
@@ -421,7 +435,14 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.11.6)
+    graphlient (0.4.0)
+      faraday (>= 1.0)
+      faraday_middleware
+      graphql-client
+    graphql (1.11.7)
+    graphql-client (0.16.0)
+      activesupport (>= 3.0)
+      graphql (~> 1.8)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -807,6 +828,7 @@ DEPENDENCIES
   byebug
   decidim!
   decidim-dev!
+  decidim-elections!
   faker (~> 2.14)
   fog-aws
   letter_opener_web (~> 1.4.0)


### PR DESCRIPTION
## ✍️ Description
In https://github.com/codegram/decidim-staging/pull/266 the `decidim-elections` gem was removed to speed up boot time, but I'm actually working on it 😅 

Restoring it with this PR