### PR TITLE
temporaly disable uglifier for staging/prod env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(:harmony => true)
+  # config.assets.js_compressor = Uglifier.new(:harmony => true)
+
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## ✍️ Description

This PR fixes an `Uglifier::Error: generators cannot be async` in [Heroku](https://dashboard.heroku.com/pipelines/62ec9bfb-126e-44e6-a43e-68d62107bbf3) or production environment, so disabling it while we find the best solution to solve it.

decidim-staging and review_apps build are failing due to this error.

