### PR TITLE
Upgrade sentry reports

### DIFF
--- a/.github/workflows/decidim_ci.yml
+++ b/.github/workflows/decidim_ci.yml
@@ -34,17 +34,6 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - name: Recover dependency cache
-        uses: actions/cache@v1
-        with:
-          path: ./vendor/bundle
-          key: ${{ runner.OS }}-deps-${{ hashFiles('Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-deps-${{ env.cache-name }}-
-            ${{ runner.OS }}-deps-
-            ${{ runner.OS }}-
-      - run: bundle install --path vendor/bundle --jobs 4 --retry 3
-        name: Bundle install
       - run: bundle exec rake db:test:prepare
         name: Setup database
       - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -43,5 +43,4 @@ group :production do
   gem "sendgrid-ruby"
   gem "sentry-ruby"
   gem "sentry-rails"
-  gem "sentry-sidekiq"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -41,5 +41,7 @@ group :production do
   gem "fog-aws"
   gem "lograge"
   gem "sendgrid-ruby"
-  gem "sentry-raven"
+  gem "sentry-ruby"
+  gem "sentry-rails"
+  gem "sentry-sidekiq"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -786,8 +786,6 @@ GEM
     sentry-ruby-core (4.2.2)
       concurrent-ruby
       faraday
-    sentry-sidekiq (4.2.1)
-      sentry-ruby-core (~> 4.2.0)
     seven_zip_ruby (1.3.0)
     simplecov (0.19.1)
       docile (~> 1.1)
@@ -884,7 +882,6 @@ DEPENDENCIES
   sendgrid-ruby
   sentry-rails
   sentry-ruby
-  sentry-sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets (~> 3.7.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,8 +776,18 @@ GEM
       rubyzip (>= 1.2.2)
     sendgrid-ruby (6.3.4)
       ruby_http_client (~> 3.4)
-    sentry-raven (3.1.0)
+    sentry-rails (4.2.2)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.2.0)
+    sentry-ruby (4.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.2.2)
+    sentry-ruby-core (4.2.2)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.2.1)
+      sentry-ruby-core (~> 4.2.0)
     seven_zip_ruby (1.3.0)
     simplecov (0.19.1)
       docile (~> 1.1)
@@ -872,7 +882,9 @@ DEPENDENCIES
   puma
   ransack (~> 2.1.1)
   sendgrid-ruby
-  sentry-raven
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets (~> 3.7.2)

--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -2,13 +2,14 @@
 # entry point, but you can change what controller it inherits from
 # so you can customize some methods.
 class DecidimController < ApplicationController
-  before_action :set_raven_context
+  before_action :set_sentry_context
 
   private
 
-  def set_raven_context
+  def set_sentry_context
     return unless Rails.application.secrets.sentry_enabled?
-    Raven.user_context({id: try(:current_user).try(:id)}.merge(session))
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+
+    Sentry.set_user({id: try(:current_user).try(:id)}.merge(session))
+    Sentry.set_extras(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,11 @@
 if Rails.application.secrets.sentry_enabled?
   Sentry.init do |config|
     config.dsn = ENV["SENTRY_DSN"]
-    config.environment = ENV["HEROKU_APP_NAME"] if ENV["HEROKU_APP_NAME"].present?
+    config.environment = if ENV["HEROKU_APP_NAME"].present?
+                           ENV["HEROKU_APP_NAME"]
+                         else
+                           "main"
+                         end
 
     config.breadcrumbs_logger = [:active_support_logger]
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,13 @@
+if Rails.application.secrets.sentry_enabled?
+  Sentry.init do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.environment = ENV["HEROKU_APP_NAME"] if ENV["HEROKU_APP_NAME"].present?
+
+    config.breadcrumbs_logger = [:active_support_logger]
+
+    # Performance
+    config.traces_sampler = lambda do |context|
+      true
+    end
+  end
+end


### PR DESCRIPTION
## ✍️ Description

Apparently, `sentry-raven` is deprecated. This PR migrates to the new system following https://docs.sentry.io/platforms/ruby/guides/rails/migration/