### PR TITLE
Update 20201009122749_add_commentable_counter_cache_to_initiatives 

### DIFF
--- a/db/migrate/20201009122749_add_commentable_counter_cache_to_initiatives.decidim_initiatives.rb
+++ b/db/migrate/20201009122749_add_commentable_counter_cache_to_initiatives.decidim_initiatives.rb
@@ -3,7 +3,7 @@
 
 class AddCommentableCounterCacheToInitiatives < ActiveRecord::Migration[5.2]
   def change
-    if defined?(Decidim::Consultations)
+    if defined?(Decidim::Initiatives)
       add_column :decidim_initiatives, :comments_count, :integer, null: false, default: 0, index: true
       Decidim::Initiative.reset_column_information
       Decidim::Initiative.find_each(&:update_comments_count)


### PR DESCRIPTION
## ✍️ Description

This PR fixes wrong module checking in migration, checks for `Decidim::Consultations` where it meant to check if defined? `Decidim::Initiatives`