### PR TITLE
chore: upgrade mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,7 +561,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
## ✍️ Description
Upgrades `mimemagic` to 0.3.10 (yup, they released yet another version 😆 ) to fix the build.

