### PR TITLE
Add node installation to review app creator workflow

### DIFF
--- a/.github/workflows/review-app-creator.yml
+++ b/.github/workflows/review-app-creator.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   RUBY_VERSION: 2.7.2
+  NODE_VERSION: 15.14.0
   DEFAULT_BRANCH: develop
   DEFAULT_REPO: decidim/decidim
   DATABASE_USERNAME: postgres
@@ -63,6 +64,10 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Change Decidim branch in Gemfile
         run: "sed -i -r 's|(DECIDIM_VERSION.*=.*\\bbranch:.*)${{ env.DEFAULT_BRANCH }}(.*)|\\1${{ github.event.inputs.decidimBranch }}\\2|' Gemfile"


### PR DESCRIPTION
## ✍️ Description

After adding Webpacker to Decidim, the `decidim:upgrade` task executes also `npm i`. When creating a review app with the GH Actions workflow, the version of node and npm is not the right one and breaks the lock file. This PR adds the installation of the right version of node before doing it.

## ✅ Fixes

(optional)

- Closes #(issue)
- Fixes #(issue)

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [ ] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots

(optional) Please post any relevant screenshots that might help understanding the scope of this functionality.

## 🔗 Relevant URLs

(optional)

* https://example.com/feature/1
* https://example.com/feature/2

## 📕Extra Documentation

(optional)

Please include links to any external documentation such as requirements, manuals, etc.
